### PR TITLE
feat(posts): add create post endpoint

### DIFF
--- a/src/entities/models/posts.interface.ts
+++ b/src/entities/models/posts.interface.ts
@@ -3,7 +3,7 @@ export interface IPosts {
   title: string
   content: string
   image_url: string
-  author_id: number
+  author_id?: number
   created_at?: Date
   updated_at?: Date
 }

--- a/src/entities/posts.entity.ts
+++ b/src/entities/posts.entity.ts
@@ -16,7 +16,7 @@ export class Posts implements IPosts {
   image_url: string
 
   @Column({ name: 'author_id', type: 'int' })
-  author_id: number
+  author_id?: number
 
   @Column({
     name: 'created_at',

--- a/src/http/controllers/posts/create-posts.ts
+++ b/src/http/controllers/posts/create-posts.ts
@@ -1,0 +1,27 @@
+import { makeCreatePostsUseCase } from '@/useCases/factory/make-create-posts-use-case'
+import { FastifyRequest, FastifyReply } from 'fastify'
+import z from 'zod'
+
+export async function createPost(request: FastifyRequest, reply: FastifyReply) {
+  const registerPostBodySchema = z.object({
+    title: z.string(),
+    content: z.string(),
+    image_url: z.string(),
+    author_id: z.number(),
+  })
+
+  const { title, content, image_url, author_id } = registerPostBodySchema.parse(
+    request.body,
+  )
+
+  const createPostUseCase = makeCreatePostsUseCase()
+
+  const post = await createPostUseCase.execute({
+    title,
+    content,
+    image_url,
+    author_id,
+  })
+
+  return reply.status(201).send(post)
+}

--- a/src/http/controllers/posts/routes.ts
+++ b/src/http/controllers/posts/routes.ts
@@ -1,6 +1,8 @@
 import { FastifyInstance } from 'fastify'
 import { findAllPosts } from './find-all-posts'
+import { createPost } from './create-posts'
 
 export async function postsRoutes(app: FastifyInstance) {
   app.get('/posts', findAllPosts)
+  app.post('/posts', createPost)
 }


### PR DESCRIPTION
Introduce a new POST /posts endpoint to handle post creation. The endpoint validates request body using Zod schema and uses a dedicated use case. Update the Posts entity and interface to make author_id optional to reflect business requirements.