### PR TITLE
feat(posts): add find post by ID endpoint

### DIFF
--- a/src/http/controllers/posts/find-post.ts
+++ b/src/http/controllers/posts/find-post.ts
@@ -1,0 +1,17 @@
+import { makeFindPostsUseCase } from '@/useCases/factory/make-find-posts'
+import { FastifyRequest, FastifyReply } from 'fastify'
+import z from 'zod'
+
+export async function findPost(request: FastifyRequest, reply: FastifyReply) {
+  const findPostParamsSchema = z.object({
+    id: z.coerce.number(),
+  })
+
+  const { id } = findPostParamsSchema.parse(request.params)
+
+  const findPostUseCase = makeFindPostsUseCase()
+
+  const post = await findPostUseCase.execute(id)
+
+  return reply.status(200).send(post)
+}

--- a/src/http/controllers/posts/routes.ts
+++ b/src/http/controllers/posts/routes.ts
@@ -1,8 +1,10 @@
 import { FastifyInstance } from 'fastify'
 import { findAllPosts } from './find-all-posts'
 import { createPost } from './create-posts'
+import { findPost } from './find-post'
 
 export async function postsRoutes(app: FastifyInstance) {
   app.get('/posts', findAllPosts)
+  app.get('/posts/:id', findPost)
   app.post('/posts', createPost)
 }

--- a/src/useCases/find-posts.ts
+++ b/src/useCases/find-posts.ts
@@ -1,10 +1,14 @@
-import { IPosts } from '@/entities/models/posts.interface'
 import { IPostsRepository } from '@/repositories/posts.repository.interface'
+import { ResourceNotFoundError } from './errors/resource-not-found-error'
 
 export class FindPostsUseCase {
   constructor(private postsRepository: IPostsRepository) {}
 
-  async execute(id: number): Promise<IPosts | null> {
-    return this.postsRepository.findById(id)
+  async execute(id: number) {
+    const post = await this.postsRepository.findById(id)
+
+    if (!post) throw new ResourceNotFoundError()
+
+    return post
   }
 }


### PR DESCRIPTION
Implement GET /posts/:id route to retrieve a single post. The use case now throws a ResourceNotFoundError if the post does not exist, ensuring proper error handling.