### PR TITLE
feat(posts): add update posts endpoint

### DIFF
--- a/src/http/controllers/posts/routes.ts
+++ b/src/http/controllers/posts/routes.ts
@@ -2,9 +2,11 @@ import { FastifyInstance } from 'fastify'
 import { findAllPosts } from './find-all-posts'
 import { createPost } from './create-posts'
 import { findPost } from './find-post'
+import { updatePosts } from './update-posts'
 
 export async function postsRoutes(app: FastifyInstance) {
   app.get('/posts', findAllPosts)
   app.get('/posts/:id', findPost)
   app.post('/posts', createPost)
+  app.put('/posts/:id', updatePosts)
 }

--- a/src/http/controllers/posts/update-posts.ts
+++ b/src/http/controllers/posts/update-posts.ts
@@ -1,0 +1,37 @@
+import { makeUpdatePostsUseCase } from '@/useCases/factory/make-update-posts'
+import { FastifyRequest, FastifyReply } from 'fastify'
+import { z } from 'zod'
+
+export async function updatePosts(
+  request: FastifyRequest,
+  reply: FastifyReply,
+) {
+  const registerParamsSchema = z.object({
+    id: z.coerce.number(),
+  })
+
+  const { id } = registerParamsSchema.parse(request.params)
+
+  const registerBodySchema = z.object({
+    title: z.string(),
+    content: z.string(),
+    image_url: z.string(),
+    author_id: z.number().optional(),
+  })
+
+  const { title, content, image_url, author_id } = registerBodySchema.parse(
+    request.body,
+  )
+
+  const updatePostsUseCase = makeUpdatePostsUseCase()
+
+  const posts = await updatePostsUseCase.execute({
+    id,
+    title,
+    content,
+    image_url,
+    author_id,
+  })
+
+  return reply.status(200).send(posts)
+}

--- a/src/repositories/typeorm/posts.repository.ts
+++ b/src/repositories/typeorm/posts.repository.ts
@@ -31,7 +31,9 @@ export class PostsRepository implements IPostsRepository {
   }
 
   async update(posts: IPosts): Promise<IPosts> {
-    return this.repository.save(posts)
+    const post = await this.findById(posts.id!)
+    const updatedPost = this.repository.merge(post!, posts)
+    return this.repository.save(updatedPost)
   }
 
   async delete(id: number): Promise<void> {

--- a/src/useCases/update-posts.ts
+++ b/src/useCases/update-posts.ts
@@ -1,10 +1,21 @@
 import { IPosts } from '@/entities/models/posts.interface'
 import { IPostsRepository } from '@/repositories/posts.repository.interface'
+import { ResourceNotFoundError } from './errors/resource-not-found-error'
 
 export class UpdatePostsUseCase {
   constructor(private postsRepository: IPostsRepository) {}
 
   async execute(posts: IPosts): Promise<IPosts> {
+    if (!posts.id) {
+      throw new ResourceNotFoundError()
+    }
+
+    const post = await this.postsRepository.findById(posts.id)
+
+    if (!post) {
+      throw new ResourceNotFoundError()
+    }
+
     return this.postsRepository.update(posts)
   }
 }


### PR DESCRIPTION
Implement PUT /posts/:id route with validation and proper error handling. The repository now uses merge before save to ensure only provided fields are updated. The use case validates post existence before attempting update.