### PR TITLE
feat(person): add person entity and create endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -4,10 +4,12 @@ import fastify from 'fastify'
 import { globalErrorHandler } from './utils/global-error-handler'
 import { postsRoutes } from './http/controllers/posts/routes'
 import { userRoutes } from './http/controllers/user/routes'
+import { personRoutes } from './http/controllers/person/routes'
 
 export const app = fastify()
 
 app.register(postsRoutes)
 app.register(userRoutes)
+app.register(personRoutes)
 
 app.setErrorHandler(globalErrorHandler)

--- a/src/entities/models/person.interface.ts
+++ b/src/entities/models/person.interface.ts
@@ -1,0 +1,8 @@
+export interface IPerson {
+  id?: number
+  cpf: string
+  name: string
+  birth: Date
+  email: string
+  user_id?: number
+}

--- a/src/entities/person.entity.ts
+++ b/src/entities/person.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm'
+import { IPerson } from './models/person.interface'
+import { User } from './user.entity'
+
+@Entity({ name: 'person' })
+export class Person implements IPerson {
+  @PrimaryGeneratedColumn('increment', { name: 'id' })
+  id?: number
+
+  @Column({ name: 'cpf', type: 'varchar' })
+  cpf: string
+
+  @Column({ name: 'name', type: 'varchar' })
+  name: string
+
+  @Column({ name: 'birth', type: 'date' })
+  birth: Date
+
+  @Column({ name: 'email', type: 'varchar' })
+  email: string
+
+  @OneToOne(() => User)
+  @JoinColumn({ name: 'user_id' })
+  user_id?: number
+}

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -11,9 +11,4 @@ export class User implements IUser {
 
   @Column({ name: 'password', type: 'varchar' })
   password: string
-
-  constructor(username: string, password: string) {
-    this.username = username
-    this.password = password
-  }
 }

--- a/src/http/controllers/person/create-person.ts
+++ b/src/http/controllers/person/create-person.ts
@@ -1,0 +1,29 @@
+import { makeCreatePersonUseCase } from '@/useCases/factory/make-create-person-use-case'
+import { FastifyReply, FastifyRequest } from 'fastify'
+import { z } from 'zod'
+
+export async function create(req: FastifyRequest, reply: FastifyReply) {
+  const registerBodySchema = z.object({
+    cpf: z.string(),
+    name: z.string(),
+    birth: z.coerce.date(),
+    email: z.string().email(),
+    user_id: z.coerce.number(),
+  })
+
+  const { cpf, name, birth, email, user_id } = registerBodySchema.parse(
+    req.body,
+  )
+
+  const createPersonUseCase = makeCreatePersonUseCase()
+
+  const person = await createPersonUseCase.execute({
+    cpf,
+    name,
+    birth,
+    email,
+    user_id,
+  })
+
+  return reply.status(201).send(person)
+}

--- a/src/http/controllers/person/routes.ts
+++ b/src/http/controllers/person/routes.ts
@@ -1,0 +1,6 @@
+import { FastifyInstance } from 'fastify'
+import { create } from './create-person'
+
+export async function personRoutes(app: FastifyInstance) {
+  app.post('/person', create)
+}

--- a/src/lib/typeorm/typeorm.ts
+++ b/src/lib/typeorm/typeorm.ts
@@ -1,3 +1,4 @@
+import { Person } from '@/entities/person.entity'
 import { Posts } from '@/entities/posts.entity'
 import { User } from '@/entities/user.entity'
 import { env } from '@/env'
@@ -10,7 +11,7 @@ export const appDataSource = new DataSource({
   username: env.DATABASE_USER,
   password: env.DATABASE_PASSWORD,
   database: env.DATABASE_NAME,
-  entities: [Posts, User],
+  entities: [Posts, User, Person],
   migrations: [],
   logging: env.NODE_ENV === 'development',
 })

--- a/src/repositories/person.repository.interface.ts
+++ b/src/repositories/person.repository.interface.ts
@@ -1,0 +1,5 @@
+import { IPerson } from '@/entities/models/person.interface'
+
+export interface IPersonRepository {
+  create(person: IPerson): Promise<IPerson | undefined>
+}

--- a/src/repositories/typeorm/person.repository.ts
+++ b/src/repositories/typeorm/person.repository.ts
@@ -1,0 +1,17 @@
+import { IPerson } from '@/entities/models/person.interface'
+import { Person } from '@/entities/person.entity'
+import { appDataSource } from '@/lib/typeorm/typeorm'
+import { Repository } from 'typeorm'
+import { IPersonRepository } from '../person.repository.interface'
+
+export class PersonRepository implements IPersonRepository {
+  private repository: Repository<Person>
+
+  constructor() {
+    this.repository = appDataSource.getRepository(Person)
+  }
+
+  async create(person: IPerson): Promise<IPerson | undefined> {
+    return this.repository.save(person)
+  }
+}

--- a/src/useCases/create-person.ts
+++ b/src/useCases/create-person.ts
@@ -1,0 +1,10 @@
+import { Person } from '@/entities/person.entity'
+import { IPersonRepository } from '@/repositories/person.repository.interface'
+
+export class CreatePersonUseCase {
+  constructor(private personRepository: IPersonRepository) {}
+
+  execute(person: Person) {
+    return this.personRepository.create(person)
+  }
+}

--- a/src/useCases/factory/make-create-person-use-case.ts
+++ b/src/useCases/factory/make-create-person-use-case.ts
@@ -1,0 +1,8 @@
+import { PersonRepository } from '@/repositories/typeorm/person.repository'
+import { CreatePersonUseCase } from '../create-person'
+
+export function makeCreatePersonUseCase() {
+  const personRepository = new PersonRepository()
+  const createPersonUseCase = new CreatePersonUseCase(personRepository)
+  return createPersonUseCase
+}


### PR DESCRIPTION
Introduce new Person entity with TypeORM model and interface. Implement repository pattern with create method, use case, and factory. Add Fastify route and controller for creating persons. Update app and database configuration to include Person entity. Remove constructor from User entity as it's no longer needed.