### PR TITLE
feat: establish post-author relation and enforce data integrity

### DIFF
--- a/build/app.js
+++ b/build/app.js
@@ -44,7 +44,7 @@ module.exports = __toCommonJS(app_exports);
 var import_reflect_metadata = require("reflect-metadata");
 
 // src/entities/person.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
@@ -106,78 +106,83 @@ __decorateClass([
   (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm2.ManyToOne)(() => Person),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
-// src/entities/person.entity.ts
-var Person = class {
-};
-__decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Person.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
-], Person.prototype, "cpf", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
-], Person.prototype, "name", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
-], Person.prototype, "birth", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
-], Person.prototype, "email", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
-], Person.prototype, "user_id", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Address, (address) => address.person)
-], Person.prototype, "address", 2);
-Person = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "person" })
-], Person);
-
 // src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 var Posts = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Posts.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "title", type: "varchar" })
 ], Posts.prototype, "title", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "content", type: "varchar" })
 ], Posts.prototype, "content", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "image_url", type: "varchar" })
 ], Posts.prototype, "image_url", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
+  (0, import_typeorm3.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm3.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm3.JoinColumn)({ name: "author_id" })
 ], Posts.prototype, "author_id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.CreateDateColumn)({
     name: "created_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "created_at", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.UpdateDateColumn)({
     name: "updated_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "updated_at", 2);
 Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
+  (0, import_typeorm3.Entity)({ name: "posts" })
 ], Posts);
+
+// src/entities/person.entity.ts
+var Person = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Person.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+], Person.prototype, "cpf", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+], Person.prototype, "name", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+], Person.prototype, "birth", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+], Person.prototype, "email", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+], Person.prototype, "user_id", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Address, (address) => address.person)
+], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
+Person = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "person" })
+], Person);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -280,6 +285,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -292,7 +315,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -328,6 +352,11 @@ var errorHandlerMap = {
     return reply.status(403).send({
       message: error.message
     });
+  },
+  DuplicateResourceError: (error, _, reply) => {
+    return reply.status(409).send({
+      message: error.message
+    });
   }
 };
 var globalErrorHandler = (error, _, reply) => {
@@ -349,12 +378,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -362,6 +393,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título
@@ -1035,6 +1067,16 @@ var PersonRepository = class {
   async create(person) {
     return this.repository.save(person);
   }
+  async findByCpf(cpf) {
+    return await this.repository.findOne({ where: { cpf } });
+  }
+};
+
+// src/useCases/errors/duplicate-resource-error.ts
+var DuplicateResourceError = class extends Error {
+  constructor() {
+    super("CPF j\xE1 cadastrado");
+  }
 };
 
 // src/useCases/create-person.ts
@@ -1042,7 +1084,11 @@ var CreatePersonUseCase = class {
   constructor(personRepository) {
     this.personRepository = personRepository;
   }
-  execute(person) {
+  async execute(person) {
+    const existingPerson = await this.personRepository.findByCpf(person.cpf);
+    if (existingPerson) {
+      throw new DuplicateResourceError();
+    }
     return this.personRepository.create(person);
   }
 };

--- a/build/entities/address.js
+++ b/build/entities/address.js
@@ -31,10 +31,10 @@ __export(address_exports, {
   Address: () => Address
 });
 module.exports = __toCommonJS(address_exports);
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/person.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 
 // src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
@@ -73,62 +73,104 @@ User = __decorateClass([
   (0, import_typeorm.Entity)({ name: "user" })
 ], User);
 
+// src/entities/posts.entity.ts
+var import_typeorm2 = require("typeorm");
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm2.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm2.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm2.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm2.Entity)({ name: "posts" })
+], Posts);
+
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm2.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
 
 // src/entities/address.ts
 var Address = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Address.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "street", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "street", type: "varchar" })
 ], Address.prototype, "street", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "city", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "city", type: "varchar" })
 ], Address.prototype, "city", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "state", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "state", type: "varchar" })
 ], Address.prototype, "state", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "zip_code", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "zip_code", type: "varchar" })
 ], Address.prototype, "zip_code", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "person_id", type: "int" })
+  (0, import_typeorm4.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm3.ManyToOne)(() => Person),
-  (0, import_typeorm3.JoinColumn)({ name: "person_id" })
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm4.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "address" })
+  (0, import_typeorm4.Entity)({ name: "address" })
 ], Address);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {

--- a/build/entities/person.entity.js
+++ b/build/entities/person.entity.js
@@ -31,7 +31,7 @@ __export(person_entity_exports, {
   Person: () => Person
 });
 module.exports = __toCommonJS(person_entity_exports);
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
@@ -93,40 +93,82 @@ __decorateClass([
   (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm2.ManyToOne)(() => Person),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
+// src/entities/posts.entity.ts
+var import_typeorm3 = require("typeorm");
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm3.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm3.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm3.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm3.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm3.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm3.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm3.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm3.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm3.Entity)({ name: "posts" })
+], Posts);
+
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm4.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "person" })
+  (0, import_typeorm4.Entity)({ name: "person" })
 ], Person);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {

--- a/build/entities/posts.entity.js
+++ b/build/entities/posts.entity.js
@@ -31,40 +31,146 @@ __export(posts_entity_exports, {
   Posts: () => Posts
 });
 module.exports = __toCommonJS(posts_entity_exports);
+var import_typeorm4 = require("typeorm");
+
+// src/entities/person.entity.ts
+var import_typeorm3 = require("typeorm");
+
+// src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
-var Posts = class {
+
+// src/entities/enums/user-role.ts
+var UserRole = /* @__PURE__ */ ((UserRole2) => {
+  UserRole2["PROFESSOR"] = "PROFESSOR";
+  UserRole2["ALUNO"] = "ALUNO";
+  return UserRole2;
+})(UserRole || {});
+
+// src/entities/user.entity.ts
+var User = class {
 };
 __decorateClass([
   (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
+], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
+  (0, import_typeorm.Column)({ name: "username", type: "varchar" })
+], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
+  (0, import_typeorm.Column)({ name: "password", type: "varchar" })
+], User.prototype, "password", 2);
 __decorateClass([
   (0, import_typeorm.Column)({
+    name: "role",
+    type: "enum",
+    enum: UserRole,
+    default: "ALUNO" /* ALUNO */
+  })
+], User.prototype, "role", 2);
+__decorateClass([
+  (0, import_typeorm.OneToOne)(() => Person, (person) => person.user_id)
+], User.prototype, "person", 2);
+User = __decorateClass([
+  (0, import_typeorm.Entity)({ name: "user" })
+], User);
+
+// src/entities/address.ts
+var import_typeorm2 = require("typeorm");
+var Address = class {
+};
+__decorateClass([
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Address.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "street", type: "varchar" })
+], Address.prototype, "street", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "city", type: "varchar" })
+], Address.prototype, "city", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "state", type: "varchar" })
+], Address.prototype, "state", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "zip_code", type: "varchar" })
+], Address.prototype, "zip_code", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
+], Address.prototype, "person_id", 2);
+__decorateClass([
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm2.JoinColumn)({ name: "person_id" })
+], Address.prototype, "person", 2);
+Address = __decorateClass([
+  (0, import_typeorm2.Entity)({ name: "address" })
+], Address);
+
+// src/entities/person.entity.ts
+var Person = class {
+};
+__decorateClass([
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Person.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
+], Person.prototype, "cpf", 2);
+__decorateClass([
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
+], Person.prototype, "name", 2);
+__decorateClass([
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
+], Person.prototype, "birth", 2);
+__decorateClass([
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
+], Person.prototype, "email", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
+], Person.prototype, "user_id", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
+], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
+Person = __decorateClass([
+  (0, import_typeorm3.Entity)({ name: "person" })
+], Person);
+
+// src/entities/posts.entity.ts
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm4.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm4.CreateDateColumn)({
     name: "created_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "created_at", 2);
 __decorateClass([
-  (0, import_typeorm.Column)({
+  (0, import_typeorm4.UpdateDateColumn)({
     name: "updated_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "updated_at", 2);
 Posts = __decorateClass([
-  (0, import_typeorm.Entity)({ name: "posts" })
+  (0, import_typeorm4.Entity)({ name: "posts" })
 ], Posts);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {

--- a/build/entities/user.entity.js
+++ b/build/entities/user.entity.js
@@ -31,10 +31,10 @@ __export(user_entity_exports, {
   User: () => User
 });
 module.exports = __toCommonJS(user_entity_exports);
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/person.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 
 // src/entities/address.ts
 var import_typeorm = require("typeorm");
@@ -59,40 +59,82 @@ __decorateClass([
   (0, import_typeorm.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm.ManyToOne)(() => Person),
+  (0, import_typeorm.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm.Entity)({ name: "address" })
 ], Address);
 
+// src/entities/posts.entity.ts
+var import_typeorm2 = require("typeorm");
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm2.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm2.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm2.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm2.Entity)({ name: "posts" })
+], Posts);
+
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm2.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
 
 // src/entities/enums/user-role.ts
@@ -106,16 +148,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({
+  (0, import_typeorm4.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -123,10 +165,10 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm4.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "user" })
+  (0, import_typeorm4.Entity)({ name: "user" })
 ], User);
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {

--- a/build/http/controllers/address/create.js
+++ b/build/http/controllers/address/create.js
@@ -33,7 +33,7 @@ __export(create_exports, {
 module.exports = __toCommonJS(create_exports);
 
 // src/entities/person.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
@@ -95,78 +95,83 @@ __decorateClass([
   (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm2.ManyToOne)(() => Person),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
-// src/entities/person.entity.ts
-var Person = class {
-};
-__decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Person.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
-], Person.prototype, "cpf", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
-], Person.prototype, "name", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
-], Person.prototype, "birth", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
-], Person.prototype, "email", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
-], Person.prototype, "user_id", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Address, (address) => address.person)
-], Person.prototype, "address", 2);
-Person = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "person" })
-], Person);
-
 // src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 var Posts = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Posts.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "title", type: "varchar" })
 ], Posts.prototype, "title", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "content", type: "varchar" })
 ], Posts.prototype, "content", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "image_url", type: "varchar" })
 ], Posts.prototype, "image_url", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
+  (0, import_typeorm3.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm3.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm3.JoinColumn)({ name: "author_id" })
 ], Posts.prototype, "author_id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.CreateDateColumn)({
     name: "created_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "created_at", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.UpdateDateColumn)({
     name: "updated_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "updated_at", 2);
 Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
+  (0, import_typeorm3.Entity)({ name: "posts" })
 ], Posts);
+
+// src/entities/person.entity.ts
+var Person = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Person.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+], Person.prototype, "cpf", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+], Person.prototype, "name", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+], Person.prototype, "birth", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+], Person.prototype, "email", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+], Person.prototype, "user_id", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Address, (address) => address.person)
+], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
+Person = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "person" })
+], Person);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });

--- a/build/http/controllers/address/find-address.js
+++ b/build/http/controllers/address/find-address.js
@@ -33,7 +33,7 @@ __export(find_address_exports, {
 module.exports = __toCommonJS(find_address_exports);
 
 // src/entities/person.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
@@ -95,78 +95,83 @@ __decorateClass([
   (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm2.ManyToOne)(() => Person),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
-// src/entities/person.entity.ts
-var Person = class {
-};
-__decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Person.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
-], Person.prototype, "cpf", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
-], Person.prototype, "name", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
-], Person.prototype, "birth", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
-], Person.prototype, "email", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
-], Person.prototype, "user_id", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Address, (address) => address.person)
-], Person.prototype, "address", 2);
-Person = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "person" })
-], Person);
-
 // src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 var Posts = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Posts.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "title", type: "varchar" })
 ], Posts.prototype, "title", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "content", type: "varchar" })
 ], Posts.prototype, "content", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "image_url", type: "varchar" })
 ], Posts.prototype, "image_url", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
+  (0, import_typeorm3.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm3.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm3.JoinColumn)({ name: "author_id" })
 ], Posts.prototype, "author_id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.CreateDateColumn)({
     name: "created_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "created_at", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.UpdateDateColumn)({
     name: "updated_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "updated_at", 2);
 Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
+  (0, import_typeorm3.Entity)({ name: "posts" })
 ], Posts);
+
+// src/entities/person.entity.ts
+var Person = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Person.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+], Person.prototype, "cpf", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+], Person.prototype, "name", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+], Person.prototype, "birth", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+], Person.prototype, "email", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+], Person.prototype, "user_id", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Address, (address) => address.person)
+], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
+Person = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "person" })
+], Person);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });

--- a/build/http/controllers/address/routes.js
+++ b/build/http/controllers/address/routes.js
@@ -33,7 +33,7 @@ __export(routes_exports, {
 module.exports = __toCommonJS(routes_exports);
 
 // src/entities/person.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
@@ -95,78 +95,83 @@ __decorateClass([
   (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm2.ManyToOne)(() => Person),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
-// src/entities/person.entity.ts
-var Person = class {
-};
-__decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Person.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
-], Person.prototype, "cpf", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
-], Person.prototype, "name", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
-], Person.prototype, "birth", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
-], Person.prototype, "email", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
-], Person.prototype, "user_id", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Address, (address) => address.person)
-], Person.prototype, "address", 2);
-Person = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "person" })
-], Person);
-
 // src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 var Posts = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Posts.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "title", type: "varchar" })
 ], Posts.prototype, "title", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "content", type: "varchar" })
 ], Posts.prototype, "content", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "image_url", type: "varchar" })
 ], Posts.prototype, "image_url", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
+  (0, import_typeorm3.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm3.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm3.JoinColumn)({ name: "author_id" })
 ], Posts.prototype, "author_id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.CreateDateColumn)({
     name: "created_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "created_at", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.UpdateDateColumn)({
     name: "updated_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "updated_at", 2);
 Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
+  (0, import_typeorm3.Entity)({ name: "posts" })
 ], Posts);
+
+// src/entities/person.entity.ts
+var Person = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Person.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+], Person.prototype, "cpf", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+], Person.prototype, "name", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+], Person.prototype, "birth", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+], Person.prototype, "email", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+], Person.prototype, "user_id", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Address, (address) => address.person)
+], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
+Person = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "person" })
+], Person);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });

--- a/build/http/controllers/person/create-person.js
+++ b/build/http/controllers/person/create-person.js
@@ -33,7 +33,7 @@ __export(create_person_exports, {
 module.exports = __toCommonJS(create_person_exports);
 
 // src/entities/person.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
@@ -95,78 +95,83 @@ __decorateClass([
   (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm2.ManyToOne)(() => Person),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
-// src/entities/person.entity.ts
-var Person = class {
-};
-__decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Person.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
-], Person.prototype, "cpf", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
-], Person.prototype, "name", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
-], Person.prototype, "birth", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
-], Person.prototype, "email", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
-], Person.prototype, "user_id", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Address, (address) => address.person)
-], Person.prototype, "address", 2);
-Person = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "person" })
-], Person);
-
 // src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 var Posts = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Posts.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "title", type: "varchar" })
 ], Posts.prototype, "title", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "content", type: "varchar" })
 ], Posts.prototype, "content", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "image_url", type: "varchar" })
 ], Posts.prototype, "image_url", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
+  (0, import_typeorm3.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm3.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm3.JoinColumn)({ name: "author_id" })
 ], Posts.prototype, "author_id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.CreateDateColumn)({
     name: "created_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "created_at", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.UpdateDateColumn)({
     name: "updated_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "updated_at", 2);
 Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
+  (0, import_typeorm3.Entity)({ name: "posts" })
 ], Posts);
+
+// src/entities/person.entity.ts
+var Person = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Person.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+], Person.prototype, "cpf", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+], Person.prototype, "name", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+], Person.prototype, "birth", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+], Person.prototype, "email", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+], Person.prototype, "user_id", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Address, (address) => address.person)
+], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
+Person = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "person" })
+], Person);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -299,6 +323,16 @@ var PersonRepository = class {
   async create(person) {
     return this.repository.save(person);
   }
+  async findByCpf(cpf) {
+    return await this.repository.findOne({ where: { cpf } });
+  }
+};
+
+// src/useCases/errors/duplicate-resource-error.ts
+var DuplicateResourceError = class extends Error {
+  constructor() {
+    super("CPF j\xE1 cadastrado");
+  }
 };
 
 // src/useCases/create-person.ts
@@ -306,7 +340,11 @@ var CreatePersonUseCase = class {
   constructor(personRepository) {
     this.personRepository = personRepository;
   }
-  execute(person) {
+  async execute(person) {
+    const existingPerson = await this.personRepository.findByCpf(person.cpf);
+    if (existingPerson) {
+      throw new DuplicateResourceError();
+    }
     return this.personRepository.create(person);
   }
 };

--- a/build/http/controllers/person/routes.js
+++ b/build/http/controllers/person/routes.js
@@ -33,7 +33,7 @@ __export(routes_exports, {
 module.exports = __toCommonJS(routes_exports);
 
 // src/entities/person.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
@@ -95,78 +95,83 @@ __decorateClass([
   (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm2.ManyToOne)(() => Person),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
-// src/entities/person.entity.ts
-var Person = class {
-};
-__decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Person.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
-], Person.prototype, "cpf", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
-], Person.prototype, "name", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
-], Person.prototype, "birth", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
-], Person.prototype, "email", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
-], Person.prototype, "user_id", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Address, (address) => address.person)
-], Person.prototype, "address", 2);
-Person = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "person" })
-], Person);
-
 // src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 var Posts = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Posts.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "title", type: "varchar" })
 ], Posts.prototype, "title", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "content", type: "varchar" })
 ], Posts.prototype, "content", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "image_url", type: "varchar" })
 ], Posts.prototype, "image_url", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
+  (0, import_typeorm3.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm3.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm3.JoinColumn)({ name: "author_id" })
 ], Posts.prototype, "author_id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.CreateDateColumn)({
     name: "created_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "created_at", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.UpdateDateColumn)({
     name: "updated_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "updated_at", 2);
 Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
+  (0, import_typeorm3.Entity)({ name: "posts" })
 ], Posts);
+
+// src/entities/person.entity.ts
+var Person = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Person.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+], Person.prototype, "cpf", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+], Person.prototype, "name", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+], Person.prototype, "birth", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+], Person.prototype, "email", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+], Person.prototype, "user_id", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Address, (address) => address.person)
+], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
+Person = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "person" })
+], Person);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -299,6 +323,16 @@ var PersonRepository = class {
   async create(person) {
     return this.repository.save(person);
   }
+  async findByCpf(cpf) {
+    return await this.repository.findOne({ where: { cpf } });
+  }
+};
+
+// src/useCases/errors/duplicate-resource-error.ts
+var DuplicateResourceError = class extends Error {
+  constructor() {
+    super("CPF j\xE1 cadastrado");
+  }
 };
 
 // src/useCases/create-person.ts
@@ -306,7 +340,11 @@ var CreatePersonUseCase = class {
   constructor(personRepository) {
     this.personRepository = personRepository;
   }
-  execute(person) {
+  async execute(person) {
+    const existingPerson = await this.personRepository.findByCpf(person.cpf);
+    if (existingPerson) {
+      throw new DuplicateResourceError();
+    }
     return this.personRepository.create(person);
   }
 };

--- a/build/http/controllers/posts/create-posts.js
+++ b/build/http/controllers/posts/create-posts.js
@@ -43,50 +43,13 @@ __export(create_posts_exports, {
 module.exports = __toCommonJS(create_posts_exports);
 
 // src/entities/posts.entity.ts
-var import_typeorm = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm.Entity)({ name: "posts" })
-], Posts);
-
-// src/repositories/typeorm/posts.repository.ts
-var import_typeorm6 = require("typeorm");
-
-// src/entities/person.entity.ts
 var import_typeorm4 = require("typeorm");
 
+// src/entities/person.entity.ts
+var import_typeorm3 = require("typeorm");
+
 // src/entities/user.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm = require("typeorm");
 
 // src/entities/enums/user-role.ts
 var UserRole = /* @__PURE__ */ ((UserRole2) => {
@@ -99,16 +62,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({
+  (0, import_typeorm.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -116,70 +79,114 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "user" })
+  (0, import_typeorm.Entity)({ name: "user" })
 ], User);
 
 // src/entities/address.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm2 = require("typeorm");
 var Address = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Address.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "street", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "street", type: "varchar" })
 ], Address.prototype, "street", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "city", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "city", type: "varchar" })
 ], Address.prototype, "city", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "state", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "state", type: "varchar" })
 ], Address.prototype, "state", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "zip_code", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "zip_code", type: "varchar" })
 ], Address.prototype, "zip_code", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "person_id", type: "int" })
+  (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm3.ManyToOne)(() => Person),
-  (0, import_typeorm3.JoinColumn)({ name: "person_id" })
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "address" })
+  (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
+
+// src/entities/posts.entity.ts
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm4.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm4.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm4.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "posts" })
+], Posts);
+
+// src/repositories/typeorm/posts.repository.ts
+var import_typeorm6 = require("typeorm");
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -282,6 +289,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -294,7 +319,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -311,12 +337,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -324,6 +352,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título

--- a/build/http/controllers/posts/delete-posts.js
+++ b/build/http/controllers/posts/delete-posts.js
@@ -33,50 +33,13 @@ __export(delete_posts_exports, {
 module.exports = __toCommonJS(delete_posts_exports);
 
 // src/entities/posts.entity.ts
-var import_typeorm = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm.Entity)({ name: "posts" })
-], Posts);
-
-// src/repositories/typeorm/posts.repository.ts
-var import_typeorm6 = require("typeorm");
-
-// src/entities/person.entity.ts
 var import_typeorm4 = require("typeorm");
 
+// src/entities/person.entity.ts
+var import_typeorm3 = require("typeorm");
+
 // src/entities/user.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm = require("typeorm");
 
 // src/entities/enums/user-role.ts
 var UserRole = /* @__PURE__ */ ((UserRole2) => {
@@ -89,16 +52,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({
+  (0, import_typeorm.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -106,70 +69,114 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "user" })
+  (0, import_typeorm.Entity)({ name: "user" })
 ], User);
 
 // src/entities/address.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm2 = require("typeorm");
 var Address = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Address.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "street", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "street", type: "varchar" })
 ], Address.prototype, "street", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "city", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "city", type: "varchar" })
 ], Address.prototype, "city", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "state", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "state", type: "varchar" })
 ], Address.prototype, "state", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "zip_code", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "zip_code", type: "varchar" })
 ], Address.prototype, "zip_code", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "person_id", type: "int" })
+  (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm3.ManyToOne)(() => Person),
-  (0, import_typeorm3.JoinColumn)({ name: "person_id" })
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "address" })
+  (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
+
+// src/entities/posts.entity.ts
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm4.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm4.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm4.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "posts" })
+], Posts);
+
+// src/repositories/typeorm/posts.repository.ts
+var import_typeorm6 = require("typeorm");
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -272,6 +279,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -284,7 +309,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -301,12 +327,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -314,6 +342,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título

--- a/build/http/controllers/posts/find-all-posts.js
+++ b/build/http/controllers/posts/find-all-posts.js
@@ -33,50 +33,13 @@ __export(find_all_posts_exports, {
 module.exports = __toCommonJS(find_all_posts_exports);
 
 // src/entities/posts.entity.ts
-var import_typeorm = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm.Entity)({ name: "posts" })
-], Posts);
-
-// src/repositories/typeorm/posts.repository.ts
-var import_typeorm6 = require("typeorm");
-
-// src/entities/person.entity.ts
 var import_typeorm4 = require("typeorm");
 
+// src/entities/person.entity.ts
+var import_typeorm3 = require("typeorm");
+
 // src/entities/user.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm = require("typeorm");
 
 // src/entities/enums/user-role.ts
 var UserRole = /* @__PURE__ */ ((UserRole2) => {
@@ -89,16 +52,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({
+  (0, import_typeorm.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -106,70 +69,114 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "user" })
+  (0, import_typeorm.Entity)({ name: "user" })
 ], User);
 
 // src/entities/address.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm2 = require("typeorm");
 var Address = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Address.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "street", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "street", type: "varchar" })
 ], Address.prototype, "street", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "city", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "city", type: "varchar" })
 ], Address.prototype, "city", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "state", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "state", type: "varchar" })
 ], Address.prototype, "state", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "zip_code", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "zip_code", type: "varchar" })
 ], Address.prototype, "zip_code", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "person_id", type: "int" })
+  (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm3.ManyToOne)(() => Person),
-  (0, import_typeorm3.JoinColumn)({ name: "person_id" })
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "address" })
+  (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
+
+// src/entities/posts.entity.ts
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm4.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm4.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm4.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "posts" })
+], Posts);
+
+// src/repositories/typeorm/posts.repository.ts
+var import_typeorm6 = require("typeorm");
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -272,6 +279,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -284,7 +309,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -301,12 +327,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -314,6 +342,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título

--- a/build/http/controllers/posts/find-post.js
+++ b/build/http/controllers/posts/find-post.js
@@ -33,50 +33,13 @@ __export(find_post_exports, {
 module.exports = __toCommonJS(find_post_exports);
 
 // src/entities/posts.entity.ts
-var import_typeorm = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm.Entity)({ name: "posts" })
-], Posts);
-
-// src/repositories/typeorm/posts.repository.ts
-var import_typeorm6 = require("typeorm");
-
-// src/entities/person.entity.ts
 var import_typeorm4 = require("typeorm");
 
+// src/entities/person.entity.ts
+var import_typeorm3 = require("typeorm");
+
 // src/entities/user.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm = require("typeorm");
 
 // src/entities/enums/user-role.ts
 var UserRole = /* @__PURE__ */ ((UserRole2) => {
@@ -89,16 +52,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({
+  (0, import_typeorm.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -106,70 +69,114 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "user" })
+  (0, import_typeorm.Entity)({ name: "user" })
 ], User);
 
 // src/entities/address.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm2 = require("typeorm");
 var Address = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Address.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "street", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "street", type: "varchar" })
 ], Address.prototype, "street", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "city", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "city", type: "varchar" })
 ], Address.prototype, "city", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "state", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "state", type: "varchar" })
 ], Address.prototype, "state", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "zip_code", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "zip_code", type: "varchar" })
 ], Address.prototype, "zip_code", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "person_id", type: "int" })
+  (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm3.ManyToOne)(() => Person),
-  (0, import_typeorm3.JoinColumn)({ name: "person_id" })
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "address" })
+  (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
+
+// src/entities/posts.entity.ts
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm4.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm4.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm4.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "posts" })
+], Posts);
+
+// src/repositories/typeorm/posts.repository.ts
+var import_typeorm6 = require("typeorm");
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -272,6 +279,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -284,7 +309,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -301,12 +327,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -314,6 +342,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título

--- a/build/http/controllers/posts/routes.js
+++ b/build/http/controllers/posts/routes.js
@@ -43,50 +43,13 @@ __export(routes_exports, {
 module.exports = __toCommonJS(routes_exports);
 
 // src/entities/posts.entity.ts
-var import_typeorm = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm.Entity)({ name: "posts" })
-], Posts);
-
-// src/repositories/typeorm/posts.repository.ts
-var import_typeorm6 = require("typeorm");
-
-// src/entities/person.entity.ts
 var import_typeorm4 = require("typeorm");
 
+// src/entities/person.entity.ts
+var import_typeorm3 = require("typeorm");
+
 // src/entities/user.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm = require("typeorm");
 
 // src/entities/enums/user-role.ts
 var UserRole = /* @__PURE__ */ ((UserRole2) => {
@@ -99,16 +62,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({
+  (0, import_typeorm.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -116,70 +79,114 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "user" })
+  (0, import_typeorm.Entity)({ name: "user" })
 ], User);
 
 // src/entities/address.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm2 = require("typeorm");
 var Address = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Address.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "street", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "street", type: "varchar" })
 ], Address.prototype, "street", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "city", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "city", type: "varchar" })
 ], Address.prototype, "city", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "state", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "state", type: "varchar" })
 ], Address.prototype, "state", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "zip_code", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "zip_code", type: "varchar" })
 ], Address.prototype, "zip_code", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "person_id", type: "int" })
+  (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm3.ManyToOne)(() => Person),
-  (0, import_typeorm3.JoinColumn)({ name: "person_id" })
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "address" })
+  (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
+
+// src/entities/posts.entity.ts
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm4.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm4.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm4.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "posts" })
+], Posts);
+
+// src/repositories/typeorm/posts.repository.ts
+var import_typeorm6 = require("typeorm");
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -282,6 +289,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -294,7 +319,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -311,12 +337,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -324,6 +352,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título

--- a/build/http/controllers/posts/search-posts.js
+++ b/build/http/controllers/posts/search-posts.js
@@ -33,50 +33,13 @@ __export(search_posts_exports, {
 module.exports = __toCommonJS(search_posts_exports);
 
 // src/entities/posts.entity.ts
-var import_typeorm = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm.Entity)({ name: "posts" })
-], Posts);
-
-// src/repositories/typeorm/posts.repository.ts
-var import_typeorm6 = require("typeorm");
-
-// src/entities/person.entity.ts
 var import_typeorm4 = require("typeorm");
 
+// src/entities/person.entity.ts
+var import_typeorm3 = require("typeorm");
+
 // src/entities/user.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm = require("typeorm");
 
 // src/entities/enums/user-role.ts
 var UserRole = /* @__PURE__ */ ((UserRole2) => {
@@ -89,16 +52,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({
+  (0, import_typeorm.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -106,70 +69,114 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "user" })
+  (0, import_typeorm.Entity)({ name: "user" })
 ], User);
 
 // src/entities/address.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm2 = require("typeorm");
 var Address = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Address.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "street", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "street", type: "varchar" })
 ], Address.prototype, "street", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "city", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "city", type: "varchar" })
 ], Address.prototype, "city", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "state", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "state", type: "varchar" })
 ], Address.prototype, "state", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "zip_code", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "zip_code", type: "varchar" })
 ], Address.prototype, "zip_code", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "person_id", type: "int" })
+  (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm3.ManyToOne)(() => Person),
-  (0, import_typeorm3.JoinColumn)({ name: "person_id" })
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "address" })
+  (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
+
+// src/entities/posts.entity.ts
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm4.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm4.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm4.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "posts" })
+], Posts);
+
+// src/repositories/typeorm/posts.repository.ts
+var import_typeorm6 = require("typeorm");
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -272,6 +279,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -284,7 +309,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -301,12 +327,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -314,6 +342,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título

--- a/build/http/controllers/posts/update-posts.js
+++ b/build/http/controllers/posts/update-posts.js
@@ -33,50 +33,13 @@ __export(update_posts_exports, {
 module.exports = __toCommonJS(update_posts_exports);
 
 // src/entities/posts.entity.ts
-var import_typeorm = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm.Entity)({ name: "posts" })
-], Posts);
-
-// src/repositories/typeorm/posts.repository.ts
-var import_typeorm6 = require("typeorm");
-
-// src/entities/person.entity.ts
 var import_typeorm4 = require("typeorm");
 
+// src/entities/person.entity.ts
+var import_typeorm3 = require("typeorm");
+
 // src/entities/user.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm = require("typeorm");
 
 // src/entities/enums/user-role.ts
 var UserRole = /* @__PURE__ */ ((UserRole2) => {
@@ -89,16 +52,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({
+  (0, import_typeorm.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -106,70 +69,114 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "user" })
+  (0, import_typeorm.Entity)({ name: "user" })
 ], User);
 
 // src/entities/address.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm2 = require("typeorm");
 var Address = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Address.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "street", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "street", type: "varchar" })
 ], Address.prototype, "street", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "city", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "city", type: "varchar" })
 ], Address.prototype, "city", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "state", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "state", type: "varchar" })
 ], Address.prototype, "state", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "zip_code", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "zip_code", type: "varchar" })
 ], Address.prototype, "zip_code", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "person_id", type: "int" })
+  (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm3.ManyToOne)(() => Person),
-  (0, import_typeorm3.JoinColumn)({ name: "person_id" })
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "address" })
+  (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
+
+// src/entities/posts.entity.ts
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm4.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm4.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm4.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "posts" })
+], Posts);
+
+// src/repositories/typeorm/posts.repository.ts
+var import_typeorm6 = require("typeorm");
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -272,6 +279,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -284,7 +309,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -301,12 +327,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -314,6 +342,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título

--- a/build/http/controllers/user/create.js
+++ b/build/http/controllers/user/create.js
@@ -40,10 +40,10 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 })(UserRole || {});
 
 // src/entities/user.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/person.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 
 // src/entities/address.ts
 var import_typeorm = require("typeorm");
@@ -68,56 +68,98 @@ __decorateClass([
   (0, import_typeorm.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm.ManyToOne)(() => Person),
+  (0, import_typeorm.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm.Entity)({ name: "address" })
 ], Address);
 
+// src/entities/posts.entity.ts
+var import_typeorm2 = require("typeorm");
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm2.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm2.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm2.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm2.Entity)({ name: "posts" })
+], Posts);
+
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm2.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
 
 // src/entities/user.entity.ts
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({
+  (0, import_typeorm4.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -125,48 +167,11 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm4.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "user" })
+  (0, import_typeorm4.Entity)({ name: "user" })
 ], User);
-
-// src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
-], Posts);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });

--- a/build/http/controllers/user/find-user.js
+++ b/build/http/controllers/user/find-user.js
@@ -33,10 +33,10 @@ __export(find_user_exports, {
 module.exports = __toCommonJS(find_user_exports);
 
 // src/entities/user.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/person.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 
 // src/entities/address.ts
 var import_typeorm = require("typeorm");
@@ -61,40 +61,82 @@ __decorateClass([
   (0, import_typeorm.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm.ManyToOne)(() => Person),
+  (0, import_typeorm.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm.Entity)({ name: "address" })
 ], Address);
 
+// src/entities/posts.entity.ts
+var import_typeorm2 = require("typeorm");
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm2.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm2.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm2.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm2.Entity)({ name: "posts" })
+], Posts);
+
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm2.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
 
 // src/entities/enums/user-role.ts
@@ -108,16 +150,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({
+  (0, import_typeorm4.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -125,48 +167,11 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm4.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "user" })
+  (0, import_typeorm4.Entity)({ name: "user" })
 ], User);
-
-// src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
-], Posts);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });

--- a/build/http/controllers/user/routes.js
+++ b/build/http/controllers/user/routes.js
@@ -40,10 +40,10 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 })(UserRole || {});
 
 // src/entities/user.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/person.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 
 // src/entities/address.ts
 var import_typeorm = require("typeorm");
@@ -68,56 +68,98 @@ __decorateClass([
   (0, import_typeorm.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm.ManyToOne)(() => Person),
+  (0, import_typeorm.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm.Entity)({ name: "address" })
 ], Address);
 
+// src/entities/posts.entity.ts
+var import_typeorm2 = require("typeorm");
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm2.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm2.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm2.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm2.Entity)({ name: "posts" })
+], Posts);
+
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm2.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
 
 // src/entities/user.entity.ts
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({
+  (0, import_typeorm4.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -125,48 +167,11 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm4.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "user" })
+  (0, import_typeorm4.Entity)({ name: "user" })
 ], User);
-
-// src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
-], Posts);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });

--- a/build/http/controllers/user/signin.js
+++ b/build/http/controllers/user/signin.js
@@ -40,10 +40,10 @@ var InvalidCredentialsError = class extends Error {
 };
 
 // src/entities/user.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/person.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 
 // src/entities/address.ts
 var import_typeorm = require("typeorm");
@@ -68,40 +68,82 @@ __decorateClass([
   (0, import_typeorm.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm.ManyToOne)(() => Person),
+  (0, import_typeorm.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm.Entity)({ name: "address" })
 ], Address);
 
+// src/entities/posts.entity.ts
+var import_typeorm2 = require("typeorm");
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm2.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm2.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm2.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm2.Entity)({ name: "posts" })
+], Posts);
+
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm2.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
 
 // src/entities/enums/user-role.ts
@@ -115,16 +157,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({
+  (0, import_typeorm4.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -132,48 +174,11 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm4.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "user" })
+  (0, import_typeorm4.Entity)({ name: "user" })
 ], User);
-
-// src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
-], Posts);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -276,6 +281,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -288,7 +311,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });

--- a/build/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.js
+++ b/build/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.js
@@ -17,34 +17,29 @@ var __copyProps = (to, from, except, desc) => {
 };
 var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
 
-// src/useCases/create-person.ts
-var create_person_exports = {};
-__export(create_person_exports, {
-  CreatePersonUseCase: () => CreatePersonUseCase
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey_exports = {};
+__export(AlterTablePostsAddAuthorForeignKey_exports, {
+  AlterTablePostsAddAuthorForeignKey1777421308811: () => AlterTablePostsAddAuthorForeignKey1777421308811
 });
-module.exports = __toCommonJS(create_person_exports);
-
-// src/useCases/errors/duplicate-resource-error.ts
-var DuplicateResourceError = class extends Error {
-  constructor() {
-    super("CPF j\xE1 cadastrado");
+module.exports = __toCommonJS(AlterTablePostsAddAuthorForeignKey_exports);
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
   }
-};
-
-// src/useCases/create-person.ts
-var CreatePersonUseCase = class {
-  constructor(personRepository) {
-    this.personRepository = personRepository;
-  }
-  async execute(person) {
-    const existingPerson = await this.personRepository.findByCpf(person.cpf);
-    if (existingPerson) {
-      throw new DuplicateResourceError();
-    }
-    return this.personRepository.create(person);
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
   }
 };
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
-  CreatePersonUseCase
+  AlterTablePostsAddAuthorForeignKey1777421308811
 });

--- a/build/lib/typeorm/typeorm.js
+++ b/build/lib/typeorm/typeorm.js
@@ -33,7 +33,7 @@ __export(typeorm_exports, {
 module.exports = __toCommonJS(typeorm_exports);
 
 // src/entities/person.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
@@ -95,78 +95,83 @@ __decorateClass([
   (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm2.ManyToOne)(() => Person),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
-// src/entities/person.entity.ts
-var Person = class {
-};
-__decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Person.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
-], Person.prototype, "cpf", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
-], Person.prototype, "name", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
-], Person.prototype, "birth", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
-], Person.prototype, "email", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
-], Person.prototype, "user_id", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Address, (address) => address.person)
-], Person.prototype, "address", 2);
-Person = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "person" })
-], Person);
-
 // src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 var Posts = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Posts.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "title", type: "varchar" })
 ], Posts.prototype, "title", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "content", type: "varchar" })
 ], Posts.prototype, "content", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "image_url", type: "varchar" })
 ], Posts.prototype, "image_url", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
+  (0, import_typeorm3.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm3.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm3.JoinColumn)({ name: "author_id" })
 ], Posts.prototype, "author_id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.CreateDateColumn)({
     name: "created_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "created_at", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.UpdateDateColumn)({
     name: "updated_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "updated_at", 2);
 Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
+  (0, import_typeorm3.Entity)({ name: "posts" })
 ], Posts);
+
+// src/entities/person.entity.ts
+var Person = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Person.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+], Person.prototype, "cpf", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+], Person.prototype, "name", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+], Person.prototype, "birth", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+], Person.prototype, "email", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+], Person.prototype, "user_id", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Address, (address) => address.person)
+], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
+Person = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "person" })
+], Person);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });

--- a/build/repositories/typeorm/address.repository.js
+++ b/build/repositories/typeorm/address.repository.js
@@ -33,7 +33,7 @@ __export(address_repository_exports, {
 module.exports = __toCommonJS(address_repository_exports);
 
 // src/entities/person.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
@@ -95,78 +95,83 @@ __decorateClass([
   (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm2.ManyToOne)(() => Person),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
-// src/entities/person.entity.ts
-var Person = class {
-};
-__decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Person.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
-], Person.prototype, "cpf", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
-], Person.prototype, "name", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
-], Person.prototype, "birth", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
-], Person.prototype, "email", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
-], Person.prototype, "user_id", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Address, (address) => address.person)
-], Person.prototype, "address", 2);
-Person = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "person" })
-], Person);
-
 // src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 var Posts = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Posts.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "title", type: "varchar" })
 ], Posts.prototype, "title", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "content", type: "varchar" })
 ], Posts.prototype, "content", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "image_url", type: "varchar" })
 ], Posts.prototype, "image_url", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
+  (0, import_typeorm3.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm3.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm3.JoinColumn)({ name: "author_id" })
 ], Posts.prototype, "author_id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.CreateDateColumn)({
     name: "created_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "created_at", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.UpdateDateColumn)({
     name: "updated_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "updated_at", 2);
 Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
+  (0, import_typeorm3.Entity)({ name: "posts" })
 ], Posts);
+
+// src/entities/person.entity.ts
+var Person = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Person.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+], Person.prototype, "cpf", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+], Person.prototype, "name", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+], Person.prototype, "birth", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+], Person.prototype, "email", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+], Person.prototype, "user_id", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Address, (address) => address.person)
+], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
+Person = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "person" })
+], Person);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });

--- a/build/repositories/typeorm/person.repository.js
+++ b/build/repositories/typeorm/person.repository.js
@@ -33,7 +33,7 @@ __export(person_repository_exports, {
 module.exports = __toCommonJS(person_repository_exports);
 
 // src/entities/person.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
@@ -95,78 +95,83 @@ __decorateClass([
   (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm2.ManyToOne)(() => Person),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
-// src/entities/person.entity.ts
-var Person = class {
-};
-__decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Person.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
-], Person.prototype, "cpf", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
-], Person.prototype, "name", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
-], Person.prototype, "birth", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
-], Person.prototype, "email", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
-], Person.prototype, "user_id", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Address, (address) => address.person)
-], Person.prototype, "address", 2);
-Person = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "person" })
-], Person);
-
 // src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 var Posts = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Posts.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "title", type: "varchar" })
 ], Posts.prototype, "title", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "content", type: "varchar" })
 ], Posts.prototype, "content", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "image_url", type: "varchar" })
 ], Posts.prototype, "image_url", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
+  (0, import_typeorm3.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm3.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm3.JoinColumn)({ name: "author_id" })
 ], Posts.prototype, "author_id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.CreateDateColumn)({
     name: "created_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "created_at", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.UpdateDateColumn)({
     name: "updated_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "updated_at", 2);
 Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
+  (0, import_typeorm3.Entity)({ name: "posts" })
 ], Posts);
+
+// src/entities/person.entity.ts
+var Person = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Person.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+], Person.prototype, "cpf", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+], Person.prototype, "name", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+], Person.prototype, "birth", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+], Person.prototype, "email", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+], Person.prototype, "user_id", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Address, (address) => address.person)
+], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
+Person = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "person" })
+], Person);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -298,6 +322,9 @@ var PersonRepository = class {
   }
   async create(person) {
     return this.repository.save(person);
+  }
+  async findByCpf(cpf) {
+    return await this.repository.findOne({ where: { cpf } });
   }
 };
 // Annotate the CommonJS export names for ESM import in node:

--- a/build/repositories/typeorm/posts.repository.js
+++ b/build/repositories/typeorm/posts.repository.js
@@ -33,50 +33,13 @@ __export(posts_repository_exports, {
 module.exports = __toCommonJS(posts_repository_exports);
 
 // src/entities/posts.entity.ts
-var import_typeorm = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm.Entity)({ name: "posts" })
-], Posts);
-
-// src/repositories/typeorm/posts.repository.ts
-var import_typeorm6 = require("typeorm");
-
-// src/entities/person.entity.ts
 var import_typeorm4 = require("typeorm");
 
+// src/entities/person.entity.ts
+var import_typeorm3 = require("typeorm");
+
 // src/entities/user.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm = require("typeorm");
 
 // src/entities/enums/user-role.ts
 var UserRole = /* @__PURE__ */ ((UserRole2) => {
@@ -89,16 +52,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({
+  (0, import_typeorm.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -106,70 +69,114 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "user" })
+  (0, import_typeorm.Entity)({ name: "user" })
 ], User);
 
 // src/entities/address.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm2 = require("typeorm");
 var Address = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Address.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "street", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "street", type: "varchar" })
 ], Address.prototype, "street", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "city", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "city", type: "varchar" })
 ], Address.prototype, "city", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "state", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "state", type: "varchar" })
 ], Address.prototype, "state", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "zip_code", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "zip_code", type: "varchar" })
 ], Address.prototype, "zip_code", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "person_id", type: "int" })
+  (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm3.ManyToOne)(() => Person),
-  (0, import_typeorm3.JoinColumn)({ name: "person_id" })
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "address" })
+  (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
+
+// src/entities/posts.entity.ts
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm4.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm4.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm4.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "posts" })
+], Posts);
+
+// src/repositories/typeorm/posts.repository.ts
+var import_typeorm6 = require("typeorm");
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -272,6 +279,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -284,7 +309,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -301,12 +327,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -314,6 +342,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título

--- a/build/repositories/typeorm/user.repository.js
+++ b/build/repositories/typeorm/user.repository.js
@@ -33,10 +33,10 @@ __export(user_repository_exports, {
 module.exports = __toCommonJS(user_repository_exports);
 
 // src/entities/user.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/person.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 
 // src/entities/address.ts
 var import_typeorm = require("typeorm");
@@ -61,40 +61,82 @@ __decorateClass([
   (0, import_typeorm.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm.ManyToOne)(() => Person),
+  (0, import_typeorm.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm.Entity)({ name: "address" })
 ], Address);
 
+// src/entities/posts.entity.ts
+var import_typeorm2 = require("typeorm");
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm2.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm2.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm2.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm2.Entity)({ name: "posts" })
+], Posts);
+
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm2.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
 
 // src/entities/enums/user-role.ts
@@ -108,16 +150,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({
+  (0, import_typeorm4.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -125,48 +167,11 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm4.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "user" })
+  (0, import_typeorm4.Entity)({ name: "user" })
 ], User);
-
-// src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
-], Posts);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });

--- a/build/server.js
+++ b/build/server.js
@@ -54,7 +54,7 @@ var env = _env.data;
 var import_reflect_metadata = require("reflect-metadata");
 
 // src/entities/person.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
@@ -116,78 +116,83 @@ __decorateClass([
   (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm2.ManyToOne)(() => Person),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
-// src/entities/person.entity.ts
-var Person = class {
-};
-__decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Person.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
-], Person.prototype, "cpf", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
-], Person.prototype, "name", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
-], Person.prototype, "birth", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
-], Person.prototype, "email", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
-], Person.prototype, "user_id", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Address, (address) => address.person)
-], Person.prototype, "address", 2);
-Person = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "person" })
-], Person);
-
 // src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 var Posts = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Posts.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "title", type: "varchar" })
 ], Posts.prototype, "title", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "content", type: "varchar" })
 ], Posts.prototype, "content", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "image_url", type: "varchar" })
 ], Posts.prototype, "image_url", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
+  (0, import_typeorm3.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm3.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm3.JoinColumn)({ name: "author_id" })
 ], Posts.prototype, "author_id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.CreateDateColumn)({
     name: "created_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "created_at", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.UpdateDateColumn)({
     name: "updated_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "updated_at", 2);
 Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
+  (0, import_typeorm3.Entity)({ name: "posts" })
 ], Posts);
+
+// src/entities/person.entity.ts
+var Person = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Person.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+], Person.prototype, "cpf", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+], Person.prototype, "name", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+], Person.prototype, "birth", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+], Person.prototype, "email", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+], Person.prototype, "user_id", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Address, (address) => address.person)
+], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
+Person = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "person" })
+], Person);
 
 // src/lib/typeorm/typeorm.ts
 var import_typeorm5 = require("typeorm");
@@ -270,6 +275,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -282,7 +305,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -318,6 +342,11 @@ var errorHandlerMap = {
     return reply.status(403).send({
       message: error.message
     });
+  },
+  DuplicateResourceError: (error, _, reply) => {
+    return reply.status(409).send({
+      message: error.message
+    });
   }
 };
 var globalErrorHandler = (error, _, reply) => {
@@ -339,12 +368,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -352,6 +383,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título
@@ -1025,6 +1057,16 @@ var PersonRepository = class {
   async create(person) {
     return this.repository.save(person);
   }
+  async findByCpf(cpf) {
+    return await this.repository.findOne({ where: { cpf } });
+  }
+};
+
+// src/useCases/errors/duplicate-resource-error.ts
+var DuplicateResourceError = class extends Error {
+  constructor() {
+    super("CPF j\xE1 cadastrado");
+  }
 };
 
 // src/useCases/create-person.ts
@@ -1032,7 +1074,11 @@ var CreatePersonUseCase = class {
   constructor(personRepository) {
     this.personRepository = personRepository;
   }
-  execute(person) {
+  async execute(person) {
+    const existingPerson = await this.personRepository.findByCpf(person.cpf);
+    if (existingPerson) {
+      throw new DuplicateResourceError();
+    }
     return this.personRepository.create(person);
   }
 };

--- a/build/useCases/errors/duplicate-resource-error.js
+++ b/build/useCases/errors/duplicate-resource-error.js
@@ -17,34 +17,18 @@ var __copyProps = (to, from, except, desc) => {
 };
 var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
 
-// src/useCases/create-person.ts
-var create_person_exports = {};
-__export(create_person_exports, {
-  CreatePersonUseCase: () => CreatePersonUseCase
-});
-module.exports = __toCommonJS(create_person_exports);
-
 // src/useCases/errors/duplicate-resource-error.ts
+var duplicate_resource_error_exports = {};
+__export(duplicate_resource_error_exports, {
+  DuplicateResourceError: () => DuplicateResourceError
+});
+module.exports = __toCommonJS(duplicate_resource_error_exports);
 var DuplicateResourceError = class extends Error {
   constructor() {
     super("CPF j\xE1 cadastrado");
   }
 };
-
-// src/useCases/create-person.ts
-var CreatePersonUseCase = class {
-  constructor(personRepository) {
-    this.personRepository = personRepository;
-  }
-  async execute(person) {
-    const existingPerson = await this.personRepository.findByCpf(person.cpf);
-    if (existingPerson) {
-      throw new DuplicateResourceError();
-    }
-    return this.personRepository.create(person);
-  }
-};
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
-  CreatePersonUseCase
+  DuplicateResourceError
 });

--- a/build/useCases/factory/make-create-address-use-case.js
+++ b/build/useCases/factory/make-create-address-use-case.js
@@ -33,7 +33,7 @@ __export(make_create_address_use_case_exports, {
 module.exports = __toCommonJS(make_create_address_use_case_exports);
 
 // src/entities/person.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
@@ -95,78 +95,83 @@ __decorateClass([
   (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm2.ManyToOne)(() => Person),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
-// src/entities/person.entity.ts
-var Person = class {
-};
-__decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Person.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
-], Person.prototype, "cpf", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
-], Person.prototype, "name", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
-], Person.prototype, "birth", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
-], Person.prototype, "email", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
-], Person.prototype, "user_id", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Address, (address) => address.person)
-], Person.prototype, "address", 2);
-Person = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "person" })
-], Person);
-
 // src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 var Posts = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Posts.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "title", type: "varchar" })
 ], Posts.prototype, "title", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "content", type: "varchar" })
 ], Posts.prototype, "content", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "image_url", type: "varchar" })
 ], Posts.prototype, "image_url", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
+  (0, import_typeorm3.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm3.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm3.JoinColumn)({ name: "author_id" })
 ], Posts.prototype, "author_id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.CreateDateColumn)({
     name: "created_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "created_at", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.UpdateDateColumn)({
     name: "updated_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "updated_at", 2);
 Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
+  (0, import_typeorm3.Entity)({ name: "posts" })
 ], Posts);
+
+// src/entities/person.entity.ts
+var Person = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Person.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+], Person.prototype, "cpf", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+], Person.prototype, "name", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+], Person.prototype, "birth", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+], Person.prototype, "email", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+], Person.prototype, "user_id", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Address, (address) => address.person)
+], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
+Person = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "person" })
+], Person);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });

--- a/build/useCases/factory/make-create-person-use-case.js
+++ b/build/useCases/factory/make-create-person-use-case.js
@@ -33,7 +33,7 @@ __export(make_create_person_use_case_exports, {
 module.exports = __toCommonJS(make_create_person_use_case_exports);
 
 // src/entities/person.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
@@ -95,78 +95,83 @@ __decorateClass([
   (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm2.ManyToOne)(() => Person),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
-// src/entities/person.entity.ts
-var Person = class {
-};
-__decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Person.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
-], Person.prototype, "cpf", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
-], Person.prototype, "name", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
-], Person.prototype, "birth", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
-], Person.prototype, "email", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
-], Person.prototype, "user_id", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Address, (address) => address.person)
-], Person.prototype, "address", 2);
-Person = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "person" })
-], Person);
-
 // src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 var Posts = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Posts.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "title", type: "varchar" })
 ], Posts.prototype, "title", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "content", type: "varchar" })
 ], Posts.prototype, "content", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "image_url", type: "varchar" })
 ], Posts.prototype, "image_url", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
+  (0, import_typeorm3.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm3.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm3.JoinColumn)({ name: "author_id" })
 ], Posts.prototype, "author_id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.CreateDateColumn)({
     name: "created_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "created_at", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.UpdateDateColumn)({
     name: "updated_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "updated_at", 2);
 Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
+  (0, import_typeorm3.Entity)({ name: "posts" })
 ], Posts);
+
+// src/entities/person.entity.ts
+var Person = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Person.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+], Person.prototype, "cpf", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+], Person.prototype, "name", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+], Person.prototype, "birth", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+], Person.prototype, "email", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+], Person.prototype, "user_id", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Address, (address) => address.person)
+], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
+Person = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "person" })
+], Person);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -299,6 +323,16 @@ var PersonRepository = class {
   async create(person) {
     return this.repository.save(person);
   }
+  async findByCpf(cpf) {
+    return await this.repository.findOne({ where: { cpf } });
+  }
+};
+
+// src/useCases/errors/duplicate-resource-error.ts
+var DuplicateResourceError = class extends Error {
+  constructor() {
+    super("CPF j\xE1 cadastrado");
+  }
 };
 
 // src/useCases/create-person.ts
@@ -306,7 +340,11 @@ var CreatePersonUseCase = class {
   constructor(personRepository) {
     this.personRepository = personRepository;
   }
-  execute(person) {
+  async execute(person) {
+    const existingPerson = await this.personRepository.findByCpf(person.cpf);
+    if (existingPerson) {
+      throw new DuplicateResourceError();
+    }
     return this.personRepository.create(person);
   }
 };

--- a/build/useCases/factory/make-create-posts-use-case.js
+++ b/build/useCases/factory/make-create-posts-use-case.js
@@ -33,50 +33,13 @@ __export(make_create_posts_use_case_exports, {
 module.exports = __toCommonJS(make_create_posts_use_case_exports);
 
 // src/entities/posts.entity.ts
-var import_typeorm = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm.Entity)({ name: "posts" })
-], Posts);
-
-// src/repositories/typeorm/posts.repository.ts
-var import_typeorm6 = require("typeorm");
-
-// src/entities/person.entity.ts
 var import_typeorm4 = require("typeorm");
 
+// src/entities/person.entity.ts
+var import_typeorm3 = require("typeorm");
+
 // src/entities/user.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm = require("typeorm");
 
 // src/entities/enums/user-role.ts
 var UserRole = /* @__PURE__ */ ((UserRole2) => {
@@ -89,16 +52,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({
+  (0, import_typeorm.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -106,70 +69,114 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "user" })
+  (0, import_typeorm.Entity)({ name: "user" })
 ], User);
 
 // src/entities/address.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm2 = require("typeorm");
 var Address = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Address.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "street", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "street", type: "varchar" })
 ], Address.prototype, "street", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "city", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "city", type: "varchar" })
 ], Address.prototype, "city", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "state", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "state", type: "varchar" })
 ], Address.prototype, "state", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "zip_code", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "zip_code", type: "varchar" })
 ], Address.prototype, "zip_code", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "person_id", type: "int" })
+  (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm3.ManyToOne)(() => Person),
-  (0, import_typeorm3.JoinColumn)({ name: "person_id" })
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "address" })
+  (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
+
+// src/entities/posts.entity.ts
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm4.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm4.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm4.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "posts" })
+], Posts);
+
+// src/repositories/typeorm/posts.repository.ts
+var import_typeorm6 = require("typeorm");
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -272,6 +279,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -284,7 +309,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -301,12 +327,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -314,6 +342,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título

--- a/build/useCases/factory/make-create-user-use-case.js
+++ b/build/useCases/factory/make-create-user-use-case.js
@@ -33,10 +33,10 @@ __export(make_create_user_use_case_exports, {
 module.exports = __toCommonJS(make_create_user_use_case_exports);
 
 // src/entities/user.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/person.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 
 // src/entities/address.ts
 var import_typeorm = require("typeorm");
@@ -61,40 +61,82 @@ __decorateClass([
   (0, import_typeorm.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm.ManyToOne)(() => Person),
+  (0, import_typeorm.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm.Entity)({ name: "address" })
 ], Address);
 
+// src/entities/posts.entity.ts
+var import_typeorm2 = require("typeorm");
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm2.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm2.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm2.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm2.Entity)({ name: "posts" })
+], Posts);
+
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm2.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
 
 // src/entities/enums/user-role.ts
@@ -108,16 +150,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({
+  (0, import_typeorm4.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -125,48 +167,11 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm4.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "user" })
+  (0, import_typeorm4.Entity)({ name: "user" })
 ], User);
-
-// src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
-], Posts);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });

--- a/build/useCases/factory/make-delete-posts-use-case.js
+++ b/build/useCases/factory/make-delete-posts-use-case.js
@@ -33,50 +33,13 @@ __export(make_delete_posts_use_case_exports, {
 module.exports = __toCommonJS(make_delete_posts_use_case_exports);
 
 // src/entities/posts.entity.ts
-var import_typeorm = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm.Entity)({ name: "posts" })
-], Posts);
-
-// src/repositories/typeorm/posts.repository.ts
-var import_typeorm6 = require("typeorm");
-
-// src/entities/person.entity.ts
 var import_typeorm4 = require("typeorm");
 
+// src/entities/person.entity.ts
+var import_typeorm3 = require("typeorm");
+
 // src/entities/user.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm = require("typeorm");
 
 // src/entities/enums/user-role.ts
 var UserRole = /* @__PURE__ */ ((UserRole2) => {
@@ -89,16 +52,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({
+  (0, import_typeorm.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -106,70 +69,114 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "user" })
+  (0, import_typeorm.Entity)({ name: "user" })
 ], User);
 
 // src/entities/address.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm2 = require("typeorm");
 var Address = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Address.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "street", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "street", type: "varchar" })
 ], Address.prototype, "street", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "city", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "city", type: "varchar" })
 ], Address.prototype, "city", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "state", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "state", type: "varchar" })
 ], Address.prototype, "state", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "zip_code", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "zip_code", type: "varchar" })
 ], Address.prototype, "zip_code", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "person_id", type: "int" })
+  (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm3.ManyToOne)(() => Person),
-  (0, import_typeorm3.JoinColumn)({ name: "person_id" })
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "address" })
+  (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
+
+// src/entities/posts.entity.ts
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm4.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm4.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm4.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "posts" })
+], Posts);
+
+// src/repositories/typeorm/posts.repository.ts
+var import_typeorm6 = require("typeorm");
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -272,6 +279,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -284,7 +309,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -301,12 +327,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -314,6 +342,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título

--- a/build/useCases/factory/make-find-address-by-person-use-case.js
+++ b/build/useCases/factory/make-find-address-by-person-use-case.js
@@ -33,7 +33,7 @@ __export(make_find_address_by_person_use_case_exports, {
 module.exports = __toCommonJS(make_find_address_by_person_use_case_exports);
 
 // src/entities/person.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/user.entity.ts
 var import_typeorm = require("typeorm");
@@ -95,78 +95,83 @@ __decorateClass([
   (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm2.ManyToOne)(() => Person),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
-// src/entities/person.entity.ts
-var Person = class {
-};
-__decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Person.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
-], Person.prototype, "cpf", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
-], Person.prototype, "name", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
-], Person.prototype, "birth", 2);
-__decorateClass([
-  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
-], Person.prototype, "email", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
-], Person.prototype, "user_id", 2);
-__decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Address, (address) => address.person)
-], Person.prototype, "address", 2);
-Person = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "person" })
-], Person);
-
 // src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 var Posts = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Posts.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "title", type: "varchar" })
 ], Posts.prototype, "title", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "content", type: "varchar" })
 ], Posts.prototype, "content", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "image_url", type: "varchar" })
 ], Posts.prototype, "image_url", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
+  (0, import_typeorm3.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm3.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm3.JoinColumn)({ name: "author_id" })
 ], Posts.prototype, "author_id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.CreateDateColumn)({
     name: "created_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "created_at", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({
+  (0, import_typeorm3.UpdateDateColumn)({
     name: "updated_at",
     type: "timestamp without time zone",
     default: () => "CURRENT_TIMESTAMP"
   })
 ], Posts.prototype, "updated_at", 2);
 Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
+  (0, import_typeorm3.Entity)({ name: "posts" })
 ], Posts);
+
+// src/entities/person.entity.ts
+var Person = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Person.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+], Person.prototype, "cpf", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+], Person.prototype, "name", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+], Person.prototype, "birth", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+], Person.prototype, "email", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+], Person.prototype, "user_id", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Address, (address) => address.person)
+], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm4.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
+Person = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "person" })
+], Person);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });

--- a/build/useCases/factory/make-find-all-posts-use-case.js
+++ b/build/useCases/factory/make-find-all-posts-use-case.js
@@ -33,50 +33,13 @@ __export(make_find_all_posts_use_case_exports, {
 module.exports = __toCommonJS(make_find_all_posts_use_case_exports);
 
 // src/entities/posts.entity.ts
-var import_typeorm = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm.Entity)({ name: "posts" })
-], Posts);
-
-// src/repositories/typeorm/posts.repository.ts
-var import_typeorm6 = require("typeorm");
-
-// src/entities/person.entity.ts
 var import_typeorm4 = require("typeorm");
 
+// src/entities/person.entity.ts
+var import_typeorm3 = require("typeorm");
+
 // src/entities/user.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm = require("typeorm");
 
 // src/entities/enums/user-role.ts
 var UserRole = /* @__PURE__ */ ((UserRole2) => {
@@ -89,16 +52,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({
+  (0, import_typeorm.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -106,70 +69,114 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "user" })
+  (0, import_typeorm.Entity)({ name: "user" })
 ], User);
 
 // src/entities/address.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm2 = require("typeorm");
 var Address = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Address.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "street", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "street", type: "varchar" })
 ], Address.prototype, "street", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "city", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "city", type: "varchar" })
 ], Address.prototype, "city", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "state", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "state", type: "varchar" })
 ], Address.prototype, "state", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "zip_code", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "zip_code", type: "varchar" })
 ], Address.prototype, "zip_code", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "person_id", type: "int" })
+  (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm3.ManyToOne)(() => Person),
-  (0, import_typeorm3.JoinColumn)({ name: "person_id" })
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "address" })
+  (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
+
+// src/entities/posts.entity.ts
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm4.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm4.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm4.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "posts" })
+], Posts);
+
+// src/repositories/typeorm/posts.repository.ts
+var import_typeorm6 = require("typeorm");
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -272,6 +279,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -284,7 +309,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -301,12 +327,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -314,6 +342,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título

--- a/build/useCases/factory/make-find-posts-use-case.js
+++ b/build/useCases/factory/make-find-posts-use-case.js
@@ -33,50 +33,13 @@ __export(make_find_posts_use_case_exports, {
 module.exports = __toCommonJS(make_find_posts_use_case_exports);
 
 // src/entities/posts.entity.ts
-var import_typeorm = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm.Entity)({ name: "posts" })
-], Posts);
-
-// src/repositories/typeorm/posts.repository.ts
-var import_typeorm6 = require("typeorm");
-
-// src/entities/person.entity.ts
 var import_typeorm4 = require("typeorm");
 
+// src/entities/person.entity.ts
+var import_typeorm3 = require("typeorm");
+
 // src/entities/user.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm = require("typeorm");
 
 // src/entities/enums/user-role.ts
 var UserRole = /* @__PURE__ */ ((UserRole2) => {
@@ -89,16 +52,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({
+  (0, import_typeorm.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -106,70 +69,114 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "user" })
+  (0, import_typeorm.Entity)({ name: "user" })
 ], User);
 
 // src/entities/address.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm2 = require("typeorm");
 var Address = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Address.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "street", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "street", type: "varchar" })
 ], Address.prototype, "street", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "city", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "city", type: "varchar" })
 ], Address.prototype, "city", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "state", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "state", type: "varchar" })
 ], Address.prototype, "state", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "zip_code", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "zip_code", type: "varchar" })
 ], Address.prototype, "zip_code", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "person_id", type: "int" })
+  (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm3.ManyToOne)(() => Person),
-  (0, import_typeorm3.JoinColumn)({ name: "person_id" })
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "address" })
+  (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
+
+// src/entities/posts.entity.ts
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm4.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm4.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm4.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "posts" })
+], Posts);
+
+// src/repositories/typeorm/posts.repository.ts
+var import_typeorm6 = require("typeorm");
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -272,6 +279,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -284,7 +309,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -301,12 +327,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -314,6 +342,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título

--- a/build/useCases/factory/make-find-with-person-use-case.js
+++ b/build/useCases/factory/make-find-with-person-use-case.js
@@ -33,10 +33,10 @@ __export(make_find_with_person_use_case_exports, {
 module.exports = __toCommonJS(make_find_with_person_use_case_exports);
 
 // src/entities/user.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/person.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 
 // src/entities/address.ts
 var import_typeorm = require("typeorm");
@@ -61,40 +61,82 @@ __decorateClass([
   (0, import_typeorm.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm.ManyToOne)(() => Person),
+  (0, import_typeorm.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm.Entity)({ name: "address" })
 ], Address);
 
+// src/entities/posts.entity.ts
+var import_typeorm2 = require("typeorm");
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm2.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm2.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm2.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm2.Entity)({ name: "posts" })
+], Posts);
+
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm2.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
 
 // src/entities/enums/user-role.ts
@@ -108,16 +150,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({
+  (0, import_typeorm4.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -125,48 +167,11 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm4.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "user" })
+  (0, import_typeorm4.Entity)({ name: "user" })
 ], User);
-
-// src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
-], Posts);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });

--- a/build/useCases/factory/make-search-posts-use-case.js
+++ b/build/useCases/factory/make-search-posts-use-case.js
@@ -33,50 +33,13 @@ __export(make_search_posts_use_case_exports, {
 module.exports = __toCommonJS(make_search_posts_use_case_exports);
 
 // src/entities/posts.entity.ts
-var import_typeorm = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm.Entity)({ name: "posts" })
-], Posts);
-
-// src/repositories/typeorm/posts.repository.ts
-var import_typeorm6 = require("typeorm");
-
-// src/entities/person.entity.ts
 var import_typeorm4 = require("typeorm");
 
+// src/entities/person.entity.ts
+var import_typeorm3 = require("typeorm");
+
 // src/entities/user.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm = require("typeorm");
 
 // src/entities/enums/user-role.ts
 var UserRole = /* @__PURE__ */ ((UserRole2) => {
@@ -89,16 +52,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({
+  (0, import_typeorm.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -106,70 +69,114 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "user" })
+  (0, import_typeorm.Entity)({ name: "user" })
 ], User);
 
 // src/entities/address.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm2 = require("typeorm");
 var Address = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Address.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "street", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "street", type: "varchar" })
 ], Address.prototype, "street", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "city", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "city", type: "varchar" })
 ], Address.prototype, "city", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "state", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "state", type: "varchar" })
 ], Address.prototype, "state", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "zip_code", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "zip_code", type: "varchar" })
 ], Address.prototype, "zip_code", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "person_id", type: "int" })
+  (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm3.ManyToOne)(() => Person),
-  (0, import_typeorm3.JoinColumn)({ name: "person_id" })
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "address" })
+  (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
+
+// src/entities/posts.entity.ts
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm4.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm4.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm4.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "posts" })
+], Posts);
+
+// src/repositories/typeorm/posts.repository.ts
+var import_typeorm6 = require("typeorm");
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -272,6 +279,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -284,7 +309,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -301,12 +327,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -314,6 +342,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título

--- a/build/useCases/factory/make-signin-use-case.js
+++ b/build/useCases/factory/make-signin-use-case.js
@@ -33,10 +33,10 @@ __export(make_signin_use_case_exports, {
 module.exports = __toCommonJS(make_signin_use_case_exports);
 
 // src/entities/user.entity.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm4 = require("typeorm");
 
 // src/entities/person.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm3 = require("typeorm");
 
 // src/entities/address.ts
 var import_typeorm = require("typeorm");
@@ -61,40 +61,82 @@ __decorateClass([
   (0, import_typeorm.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm.ManyToOne)(() => Person),
+  (0, import_typeorm.ManyToOne)(() => Person, (person) => person.address),
   (0, import_typeorm.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
   (0, import_typeorm.Entity)({ name: "address" })
 ], Address);
 
+// src/entities/posts.entity.ts
+var import_typeorm2 = require("typeorm");
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm2.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm2.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm2.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm2.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm2.Entity)({ name: "posts" })
+], Posts);
+
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm2.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
 
 // src/entities/enums/user-role.ts
@@ -108,16 +150,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm4.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({
+  (0, import_typeorm4.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -125,48 +167,11 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm3.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm4.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "user" })
+  (0, import_typeorm4.Entity)({ name: "user" })
 ], User);
-
-// src/entities/posts.entity.ts
-var import_typeorm4 = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm4.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "posts" })
-], Posts);
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -269,6 +274,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -281,7 +304,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });

--- a/build/useCases/factory/make-update-posts-use-case.js
+++ b/build/useCases/factory/make-update-posts-use-case.js
@@ -33,50 +33,13 @@ __export(make_update_posts_use_case_exports, {
 module.exports = __toCommonJS(make_update_posts_use_case_exports);
 
 // src/entities/posts.entity.ts
-var import_typeorm = require("typeorm");
-var Posts = class {
-};
-__decorateClass([
-  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
-], Posts.prototype, "id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "title", type: "varchar" })
-], Posts.prototype, "title", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "content", type: "varchar" })
-], Posts.prototype, "content", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "image_url", type: "varchar" })
-], Posts.prototype, "image_url", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({ name: "author_id", type: "int" })
-], Posts.prototype, "author_id", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "created_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "created_at", 2);
-__decorateClass([
-  (0, import_typeorm.Column)({
-    name: "updated_at",
-    type: "timestamp without time zone",
-    default: () => "CURRENT_TIMESTAMP"
-  })
-], Posts.prototype, "updated_at", 2);
-Posts = __decorateClass([
-  (0, import_typeorm.Entity)({ name: "posts" })
-], Posts);
-
-// src/repositories/typeorm/posts.repository.ts
-var import_typeorm6 = require("typeorm");
-
-// src/entities/person.entity.ts
 var import_typeorm4 = require("typeorm");
 
+// src/entities/person.entity.ts
+var import_typeorm3 = require("typeorm");
+
 // src/entities/user.entity.ts
-var import_typeorm2 = require("typeorm");
+var import_typeorm = require("typeorm");
 
 // src/entities/enums/user-role.ts
 var UserRole = /* @__PURE__ */ ((UserRole2) => {
@@ -89,16 +52,16 @@ var UserRole = /* @__PURE__ */ ((UserRole2) => {
 var User = class {
 };
 __decorateClass([
-  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], User.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "username", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "username", type: "varchar" })
 ], User.prototype, "username", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({ name: "password", type: "varchar" })
+  (0, import_typeorm.Column)({ name: "password", type: "varchar" })
 ], User.prototype, "password", 2);
 __decorateClass([
-  (0, import_typeorm2.Column)({
+  (0, import_typeorm.Column)({
     name: "role",
     type: "enum",
     enum: UserRole,
@@ -106,70 +69,114 @@ __decorateClass([
   })
 ], User.prototype, "role", 2);
 __decorateClass([
-  (0, import_typeorm2.OneToOne)(() => Person, (person) => person.user_id)
+  (0, import_typeorm.OneToOne)(() => Person, (person) => person.user_id)
 ], User.prototype, "person", 2);
 User = __decorateClass([
-  (0, import_typeorm2.Entity)({ name: "user" })
+  (0, import_typeorm.Entity)({ name: "user" })
 ], User);
 
 // src/entities/address.ts
-var import_typeorm3 = require("typeorm");
+var import_typeorm2 = require("typeorm");
 var Address = class {
 };
 __decorateClass([
-  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm2.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Address.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "street", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "street", type: "varchar" })
 ], Address.prototype, "street", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "city", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "city", type: "varchar" })
 ], Address.prototype, "city", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "state", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "state", type: "varchar" })
 ], Address.prototype, "state", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "zip_code", type: "varchar" })
+  (0, import_typeorm2.Column)({ name: "zip_code", type: "varchar" })
 ], Address.prototype, "zip_code", 2);
 __decorateClass([
-  (0, import_typeorm3.Column)({ name: "person_id", type: "int" })
+  (0, import_typeorm2.Column)({ name: "person_id", type: "int" })
 ], Address.prototype, "person_id", 2);
 __decorateClass([
-  (0, import_typeorm3.ManyToOne)(() => Person),
-  (0, import_typeorm3.JoinColumn)({ name: "person_id" })
+  (0, import_typeorm2.ManyToOne)(() => Person, (person) => person.address),
+  (0, import_typeorm2.JoinColumn)({ name: "person_id" })
 ], Address.prototype, "person", 2);
 Address = __decorateClass([
-  (0, import_typeorm3.Entity)({ name: "address" })
+  (0, import_typeorm2.Entity)({ name: "address" })
 ], Address);
 
 // src/entities/person.entity.ts
 var Person = class {
 };
 __decorateClass([
-  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+  (0, import_typeorm3.PrimaryGeneratedColumn)("increment", { name: "id" })
 ], Person.prototype, "id", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "cpf", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "cpf", type: "varchar" })
 ], Person.prototype, "cpf", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "name", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "name", type: "varchar" })
 ], Person.prototype, "name", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "birth", type: "date" })
+  (0, import_typeorm3.Column)({ name: "birth", type: "date" })
 ], Person.prototype, "birth", 2);
 __decorateClass([
-  (0, import_typeorm4.Column)({ name: "email", type: "varchar" })
+  (0, import_typeorm3.Column)({ name: "email", type: "varchar" })
 ], Person.prototype, "email", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => User, (user) => user.person),
-  (0, import_typeorm4.JoinColumn)({ name: "user_id" })
+  (0, import_typeorm3.OneToOne)(() => User, (user) => user.person),
+  (0, import_typeorm3.JoinColumn)({ name: "user_id" })
 ], Person.prototype, "user_id", 2);
 __decorateClass([
-  (0, import_typeorm4.OneToOne)(() => Address, (address) => address.person)
+  (0, import_typeorm3.OneToMany)(() => Address, (address) => address.person)
 ], Person.prototype, "address", 2);
+__decorateClass([
+  (0, import_typeorm3.OneToMany)(() => Posts, (posts) => posts.author_id)
+], Person.prototype, "posts", 2);
 Person = __decorateClass([
-  (0, import_typeorm4.Entity)({ name: "person" })
+  (0, import_typeorm3.Entity)({ name: "person" })
 ], Person);
+
+// src/entities/posts.entity.ts
+var Posts = class {
+};
+__decorateClass([
+  (0, import_typeorm4.PrimaryGeneratedColumn)("increment", { name: "id" })
+], Posts.prototype, "id", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "title", type: "varchar" })
+], Posts.prototype, "title", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "content", type: "varchar" })
+], Posts.prototype, "content", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "image_url", type: "varchar" })
+], Posts.prototype, "image_url", 2);
+__decorateClass([
+  (0, import_typeorm4.Column)({ name: "author_id", type: "int" }),
+  (0, import_typeorm4.ManyToOne)(() => Person, (person) => person.posts),
+  (0, import_typeorm4.JoinColumn)({ name: "author_id" })
+], Posts.prototype, "author_id", 2);
+__decorateClass([
+  (0, import_typeorm4.CreateDateColumn)({
+    name: "created_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "created_at", 2);
+__decorateClass([
+  (0, import_typeorm4.UpdateDateColumn)({
+    name: "updated_at",
+    type: "timestamp without time zone",
+    default: () => "CURRENT_TIMESTAMP"
+  })
+], Posts.prototype, "updated_at", 2);
+Posts = __decorateClass([
+  (0, import_typeorm4.Entity)({ name: "posts" })
+], Posts);
+
+// src/repositories/typeorm/posts.repository.ts
+var import_typeorm6 = require("typeorm");
 
 // src/env/index.ts
 var import_config = require("dotenv/config");
@@ -272,6 +279,24 @@ var AlterTablePersonUniqueCpf1777408444519 = class {
   }
 };
 
+// src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+var AlterTablePostsAddAuthorForeignKey1777421308811 = class {
+  async up(queryRunner) {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`);
+  }
+  async down(queryRunner) {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `);
+  }
+};
+
 // src/lib/typeorm/typeorm.ts
 var appDataSource = new import_typeorm5.DataSource({
   type: "postgres",
@@ -284,7 +309,8 @@ var appDataSource = new import_typeorm5.DataSource({
   migrations: [
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
-    AlterTablePersonUniqueCpf1777408444519
+    AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811
   ],
   logging: env.NODE_ENV === "development"
 });
@@ -301,12 +327,14 @@ var PostsRepository = class {
   }
   async findAll(page, limit) {
     return this.repository.find({
+      relations: ["author_id"],
       skip: (page - 1) * limit,
       take: limit
     });
   }
   async findById(id) {
     return this.repository.findOne({
+      relations: ["author_id"],
       where: {
         id
       }
@@ -314,6 +342,7 @@ var PostsRepository = class {
   }
   async search(query) {
     return this.repository.find({
+      relations: ["author_id"],
       where: [
         { title: (0, import_typeorm6.ILike)(`%${query}%`) },
         // Busca no título

--- a/build/utils/global-error-handler.js
+++ b/build/utils/global-error-handler.js
@@ -68,6 +68,11 @@ var errorHandlerMap = {
     return reply.status(403).send({
       message: error.message
     });
+  },
+  DuplicateResourceError: (error, _, reply) => {
+    return reply.status(409).send({
+      message: error.message
+    });
   }
 };
 var globalErrorHandler = (error, _, reply) => {

--- a/src/entities/address.ts
+++ b/src/entities/address.ts
@@ -28,7 +28,7 @@ export class Address implements IAddress {
   @Column({ name: 'person_id', type: 'int' })
   person_id: number
 
-  @ManyToOne(() => Person)
+  @ManyToOne(() => Person, (person) => person.address)
   @JoinColumn({ name: 'person_id' })
   person?: Person
 }

--- a/src/entities/models/posts.interface.ts
+++ b/src/entities/models/posts.interface.ts
@@ -1,9 +1,11 @@
+import { IPerson } from './person.interface'
+
 export interface IPosts {
   id?: number
   title: string
   content: string
   image_url: string
-  author_id?: number
+  author_id?: IPerson
   created_at?: Date
   updated_at?: Date
 }

--- a/src/entities/person.entity.ts
+++ b/src/entities/person.entity.ts
@@ -2,12 +2,14 @@ import {
   Column,
   Entity,
   JoinColumn,
+  OneToMany,
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm'
 import { IPerson } from './models/person.interface'
 import { User } from './user.entity'
 import { Address } from './address'
+import { Posts } from './posts.entity'
 
 @Entity({ name: 'person' })
 export class Person implements IPerson {
@@ -30,6 +32,9 @@ export class Person implements IPerson {
   @JoinColumn({ name: 'user_id' })
   user_id?: number
 
-  @OneToOne(() => Address, (address) => address.person)
+  @OneToMany(() => Address, (address) => address.person)
   address?: Address
+
+  @OneToMany(() => Posts, (posts) => posts.author_id)
+  posts?: Posts[]
 }

--- a/src/entities/posts.entity.ts
+++ b/src/entities/posts.entity.ts
@@ -1,5 +1,14 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm'
 import { IPosts } from './models/posts.interface'
+import { Person } from './person.entity'
 
 @Entity({ name: 'posts' })
 export class Posts implements IPosts {
@@ -16,16 +25,18 @@ export class Posts implements IPosts {
   image_url: string
 
   @Column({ name: 'author_id', type: 'int' })
-  author_id?: number
+  @ManyToOne(() => Person, (person) => person.posts)
+  @JoinColumn({ name: 'author_id' })
+  author_id?: Person
 
-  @Column({
+  @CreateDateColumn({
     name: 'created_at',
     type: 'timestamp without time zone',
     default: () => 'CURRENT_TIMESTAMP',
   })
   created_at?: Date
 
-  @Column({
+  @UpdateDateColumn({
     name: 'updated_at',
     type: 'timestamp without time zone',
     default: () => 'CURRENT_TIMESTAMP',

--- a/src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
+++ b/src/lib/typeorm/migrations/1777421308811-AlterTablePostsAddAuthorForeignKey.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AlterTablePostsAddAuthorForeignKey1777421308811 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE posts
+            ADD CONSTRAINT fk_posts_author
+            FOREIGN KEY (author_id)
+            REFERENCES person(id)
+            ON DELETE RESTRICT
+            ON UPDATE CASCADE`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE posts
+      DROP CONSTRAINT IF EXISTS fk_posts_author
+    `)
+  }
+}

--- a/src/lib/typeorm/typeorm.ts
+++ b/src/lib/typeorm/typeorm.ts
@@ -7,6 +7,7 @@ import { UserAddRole1773452300096 } from './migrations/1773452300096-UserAddRole
 import { Address } from '@/entities/address'
 import { UpdateUserRoleToUppercase1773790761895 } from './migrations/1773790761895-UpdateUserRoleToUppercase'
 import { AlterTablePersonUniqueCpf1777408444519 } from './migrations/1777408444519-AlterTablePersonUniqueCpf'
+import { AlterTablePostsAddAuthorForeignKey1777421308811 } from './migrations/1777421308811-AlterTablePostsAddAuthorForeignKey'
 
 export const appDataSource = new DataSource({
   type: 'postgres',
@@ -20,6 +21,7 @@ export const appDataSource = new DataSource({
     UserAddRole1773452300096,
     UpdateUserRoleToUppercase1773790761895,
     AlterTablePersonUniqueCpf1777408444519,
+    AlterTablePostsAddAuthorForeignKey1777421308811,
   ],
   logging: env.NODE_ENV === 'development',
 })

--- a/src/repositories/typeorm/posts.repository.ts
+++ b/src/repositories/typeorm/posts.repository.ts
@@ -1,18 +1,51 @@
 import { IPosts } from '@/entities/models/posts.interface'
 import { IPostsRepository } from '../posts.repository.interface'
 import { Posts } from '@/entities/posts.entity'
+import { Person } from '@/entities/person.entity'
 import { ILike, Repository } from 'typeorm'
 import { appDataSource } from '@/lib/typeorm/typeorm'
+import { InvalidRelationError } from '@/useCases/errors/invalid-relation-error'
 
 export class PostsRepository implements IPostsRepository {
   private repository: Repository<Posts>
+  private personRepository: Repository<Person>
 
   constructor() {
     this.repository = appDataSource.getRepository(Posts)
+    this.personRepository = appDataSource.getRepository(Person)
+  }
+
+  private getAuthorId(author: IPosts['author_id']): number | undefined {
+    if (!author) return undefined
+
+    if (typeof author === 'number') {
+      return author
+    }
+
+    return author.id
+  }
+
+  private async validateAuthorExists(
+    author: IPosts['author_id'],
+  ): Promise<number | undefined> {
+    const authorId = this.getAuthorId(author)
+
+    if (!authorId) return undefined
+
+    const existingAuthor = await this.personRepository.findOne({
+      where: { id: authorId },
+    })
+
+    if (!existingAuthor) {
+      throw new InvalidRelationError()
+    }
+
+    return authorId
   }
 
   async findAll(page: number, limit: number): Promise<IPosts[]> {
     return this.repository.find({
+      relations: ['author_id'],
       skip: (page - 1) * limit,
       take: limit,
     })
@@ -20,6 +53,7 @@ export class PostsRepository implements IPostsRepository {
 
   async findById(id: number): Promise<IPosts | null> {
     return this.repository.findOne({
+      relations: ['author_id'],
       where: {
         id,
       },
@@ -28,6 +62,7 @@ export class PostsRepository implements IPostsRepository {
 
   async search(query: string): Promise<IPosts[]> {
     return this.repository.find({
+      relations: ['author_id'],
       where: [
         { title: ILike(`%${query}%`) }, // Busca no título
         { content: ILike(`%${query}%`) }, // Busca no conteúdo
@@ -36,13 +71,23 @@ export class PostsRepository implements IPostsRepository {
   }
 
   async create(posts: IPosts): Promise<IPosts> {
-    return this.repository.save(posts)
+    const authorId = await this.validateAuthorExists(posts.author_id)
+
+    return await this.repository.save({
+      ...posts,
+      author_id: authorId as never,
+    })
   }
 
   async update(posts: IPosts): Promise<IPosts> {
     const post = await this.findById(posts.id!)
     const updatedPost = this.repository.merge(post!, posts)
-    return this.repository.save(updatedPost)
+    const authorId = await this.validateAuthorExists(updatedPost.author_id)
+
+    return await this.repository.save({
+      ...updatedPost,
+      author_id: authorId as never,
+    })
   }
 
   async delete(id: number): Promise<void> {

--- a/src/useCases/errors/invalid-relation-error.ts
+++ b/src/useCases/errors/invalid-relation-error.ts
@@ -1,0 +1,5 @@
+export class InvalidRelationError extends Error {
+  constructor() {
+    super('Invalid relation error')
+  }
+}

--- a/src/useCases/update-posts.ts
+++ b/src/useCases/update-posts.ts
@@ -3,9 +3,11 @@ import { IPostsRepository } from '@/repositories/posts.repository.interface'
 import { ResourceNotFoundError } from './errors/resource-not-found-error'
 import { UserRole } from '@/entities/enums/user-role'
 import { UnauthorizedError } from './errors/UnauthorizedError'
+import { Repository } from 'typeorm'
 
 export class UpdatePostsUseCase {
   constructor(private postsRepository: IPostsRepository) {}
+  private repository: Repository<IPosts>
 
   async execute(posts: IPosts, role: string): Promise<IPosts> {
     if (!posts.id) {

--- a/src/utils/global-error-handler.ts
+++ b/src/utils/global-error-handler.ts
@@ -37,6 +37,11 @@ export const errorHandlerMap: ErrorHandlerMap = {
       message: error.message,
     })
   },
+  InvalidRelationError: (error, _, reply) => {
+    return reply.status(400).send({
+      message: error.message,
+    })
+  },
 }
 
 export const globalErrorHandler = (


### PR DESCRIPTION
- Add foreign key constraint between posts and person tables via migration
- Update entity relationships (OneToMany/ManyToOne) between Person, Posts, and Address
- Introduce InvalidRelationError and DuplicateResourceError for validation
- Modify posts repository to validate author existence and handle relations
- Update global error handler to include new error types
- Ensure person CPF uniqueness and prevent duplicate resource creation
- Adjust entity interfaces and decorators to support relation mapping